### PR TITLE
feat(pricing): Enhance sign-up process with plan and period persistence

### DIFF
--- a/src/components/pricing-table.tsx
+++ b/src/components/pricing-table.tsx
@@ -136,8 +136,13 @@ function PricingTableContent() {
 										{formatAmountCents(unitAmount, currency)}
 										<span className="text-sm">{t(`${period}Period`)}</span>
 									</CardDescription>
+									{/* When user starts from a paid plan, carry plan and period through sign-up */}
 									<Button asChild className="mt-4 w-full">
-										<Link href="/auth/sign-up">{tCommon("getStarted")}</Link>
+										<Link
+											href={`/auth/sign-up?plan=${(plan.name || "").toLowerCase()}&period=${period}`}
+										>
+											{tCommon("getStarted")}
+										</Link>
 									</Button>
 								</CardHeader>
 								<Separator />

--- a/src/components/pricing.tsx
+++ b/src/components/pricing.tsx
@@ -100,7 +100,11 @@ function PricingContent() {
 								</div>
 
 								<Button asChild className="w-full">
-									<Link href="/auth/sign-up">{tCommon("getStarted")}</Link>
+									<Link
+										href={`/auth/sign-up?plan=${paidPlanName}&period=monthly`}
+									>
+										{tCommon("getStarted")}
+									</Link>
 								</Button>
 							</div>
 

--- a/src/modules/auth/ui/views/signup-view.tsx
+++ b/src/modules/auth/ui/views/signup-view.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { AuthCard } from "@daveyplate/better-auth-ui";
+import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { useEffect } from "react";
 import { IsoLogo } from "@/components/isologo";
 import { Card, CardContent } from "@/components/ui/card";
 import { Link } from "@/modules/i18n/navigation";
@@ -9,6 +11,23 @@ import { Link } from "@/modules/i18n/navigation";
 export const SignUpView = () => {
 	const t = useTranslations("authUI");
 	const tCommon = useTranslations("common");
+	const searchParams = useSearchParams();
+
+	// Persist selected plan/period from pricing CTAs to complete upgrade post-signup
+	useEffect(() => {
+		const plan = searchParams.get("plan");
+		const period = searchParams.get("period");
+		if (plan && period) {
+			try {
+				localStorage.setItem(
+					"postSignupUpgrade",
+					JSON.stringify({ plan, period }),
+				);
+			} catch {
+				// noop
+			}
+		}
+	}, [searchParams]);
 
 	return (
 		<div className="flex flex-col gap-6">


### PR DESCRIPTION
- Updated the `PricingTableContent` and `PricingContent` components to include query parameters for the selected plan and billing period in the sign-up link, improving user experience by retaining user choices.
- Implemented local storage handling in the `NewOrganizationForm` to initiate a Stripe upgrade if the user started from a paid plan, ensuring a seamless transition post-signup.
- Added a `useEffect` hook in the `SignUpView` to persist the selected plan and period, enhancing the upgrade process after user registration.
- Ensured all changes adhere to coding standards and maintain modularity throughout the codebase.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Improved the sign-up flow by carrying the selected plan and billing period from pricing to registration, and automatically starting the Stripe upgrade after sign-up for paid plans.

- **New Features**
 - Added plan and period query parameters to sign-up links in pricing components.
 - Persisted user choices in local storage and triggered Stripe upgrade post-registration.

<!-- End of auto-generated description by cubic. -->

